### PR TITLE
refactor: async FilePickerService

### DIFF
--- a/SwiftDiffusion.xcodeproj/project.pbxproj
+++ b/SwiftDiffusion.xcodeproj/project.pbxproj
@@ -120,8 +120,8 @@
 		2996D0A52B6EE45E00B487D5 /* ScriptManager */ = {
 			isa = PBXGroup;
 			children = (
-				2996D0A62B6EE47A00B487D5 /* ScriptManager.swift */,
 				2996D0AB2B6F1FBD00B487D5 /* ScriptState.swift */,
+				2996D0A62B6EE47A00B487D5 /* ScriptManager.swift */,
 				2996D0A82B6EEFA700B487D5 /* ConfigFileManager.swift */,
 			);
 			path = ScriptManager;

--- a/SwiftDiffusion.xcodeproj/project.pbxproj
+++ b/SwiftDiffusion.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		297196492B7150B5000F7960 /* ConsoleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 297196482B7150B5000F7960 /* ConsoleView.swift */; };
 		2971964C2B715191000F7960 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2971964B2B715191000F7960 /* Constants.swift */; };
 		297196502B7151FE000F7960 /* FileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2971964F2B7151FE000F7960 /* FileManager.swift */; };
+		297196532B71538C000F7960 /* FilePickerService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 297196522B71538C000F7960 /* FilePickerService.swift */; };
 		2996D0942B6ED5B000B487D5 /* SwiftDiffusionApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2996D0932B6ED5B000B487D5 /* SwiftDiffusionApp.swift */; };
 		2996D0962B6ED5B000B487D5 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2996D0952B6ED5B000B487D5 /* ContentView.swift */; };
 		2996D0982B6ED5B100B487D5 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2996D0972B6ED5B100B487D5 /* Assets.xcassets */; };
@@ -23,6 +24,7 @@
 		297196482B7150B5000F7960 /* ConsoleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsoleView.swift; sourceTree = "<group>"; };
 		2971964B2B715191000F7960 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		2971964F2B7151FE000F7960 /* FileManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileManager.swift; sourceTree = "<group>"; };
+		297196522B71538C000F7960 /* FilePickerService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePickerService.swift; sourceTree = "<group>"; };
 		2996D0902B6ED5B000B487D5 /* SwiftDiffusion.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftDiffusion.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2996D0932B6ED5B000B487D5 /* SwiftDiffusionApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDiffusionApp.swift; sourceTree = "<group>"; };
 		2996D0952B6ED5B000B487D5 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -77,6 +79,14 @@
 			path = FileManager;
 			sourceTree = "<group>";
 		};
+		297196512B715380000F7960 /* Services */ = {
+			isa = PBXGroup;
+			children = (
+				297196522B71538C000F7960 /* FilePickerService.swift */,
+			);
+			path = Services;
+			sourceTree = "<group>";
+		};
 		2996D0872B6ED5B000B487D5 = {
 			isa = PBXGroup;
 			children = (
@@ -98,6 +108,7 @@
 			children = (
 				2996D0932B6ED5B000B487D5 /* SwiftDiffusionApp.swift */,
 				2996D0952B6ED5B000B487D5 /* ContentView.swift */,
+				297196512B715380000F7960 /* Services */,
 				297196472B715061000F7960 /* Views */,
 				2971964D2B7151E2000F7960 /* Managers */,
 				2996D0A42B6EE44E00B487D5 /* PythonInterface */,
@@ -210,6 +221,7 @@
 				2996D0A72B6EE47A00B487D5 /* ScriptManager.swift in Sources */,
 				2996D0AC2B6F1FBD00B487D5 /* ScriptState.swift in Sources */,
 				2971964C2B715191000F7960 /* Constants.swift in Sources */,
+				297196532B71538C000F7960 /* FilePickerService.swift in Sources */,
 				297196492B7150B5000F7960 /* ConsoleView.swift in Sources */,
 				2996D0A92B6EEFA700B487D5 /* ConfigFileManager.swift in Sources */,
 				297196502B7151FE000F7960 /* FileManager.swift in Sources */,

--- a/SwiftDiffusion.xcodeproj/project.pbxproj
+++ b/SwiftDiffusion.xcodeproj/project.pbxproj
@@ -9,7 +9,6 @@
 /* Begin PBXBuildFile section */
 		297196492B7150B5000F7960 /* ConsoleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 297196482B7150B5000F7960 /* ConsoleView.swift */; };
 		2971964C2B715191000F7960 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2971964B2B715191000F7960 /* Constants.swift */; };
-		297196502B7151FE000F7960 /* FileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2971964F2B7151FE000F7960 /* FileManager.swift */; };
 		297196532B71538C000F7960 /* FilePickerService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 297196522B71538C000F7960 /* FilePickerService.swift */; };
 		2996D0942B6ED5B000B487D5 /* SwiftDiffusionApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2996D0932B6ED5B000B487D5 /* SwiftDiffusionApp.swift */; };
 		2996D0962B6ED5B000B487D5 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2996D0952B6ED5B000B487D5 /* ContentView.swift */; };
@@ -23,7 +22,6 @@
 /* Begin PBXFileReference section */
 		297196482B7150B5000F7960 /* ConsoleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsoleView.swift; sourceTree = "<group>"; };
 		2971964B2B715191000F7960 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
-		2971964F2B7151FE000F7960 /* FileManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileManager.swift; sourceTree = "<group>"; };
 		297196522B71538C000F7960 /* FilePickerService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePickerService.swift; sourceTree = "<group>"; };
 		2996D0902B6ED5B000B487D5 /* SwiftDiffusion.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftDiffusion.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2996D0932B6ED5B000B487D5 /* SwiftDiffusionApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDiffusionApp.swift; sourceTree = "<group>"; };
@@ -63,22 +61,6 @@
 			path = Settings;
 			sourceTree = "<group>";
 		};
-		2971964D2B7151E2000F7960 /* Managers */ = {
-			isa = PBXGroup;
-			children = (
-				2971964E2B7151F0000F7960 /* FileManager */,
-			);
-			path = Managers;
-			sourceTree = "<group>";
-		};
-		2971964E2B7151F0000F7960 /* FileManager */ = {
-			isa = PBXGroup;
-			children = (
-				2971964F2B7151FE000F7960 /* FileManager.swift */,
-			);
-			path = FileManager;
-			sourceTree = "<group>";
-		};
 		297196512B715380000F7960 /* Services */ = {
 			isa = PBXGroup;
 			children = (
@@ -110,7 +92,6 @@
 				2996D0952B6ED5B000B487D5 /* ContentView.swift */,
 				297196512B715380000F7960 /* Services */,
 				297196472B715061000F7960 /* Views */,
-				2971964D2B7151E2000F7960 /* Managers */,
 				2996D0A42B6EE44E00B487D5 /* PythonInterface */,
 				2971964A2B715184000F7960 /* Settings */,
 				2996D0972B6ED5B100B487D5 /* Assets.xcassets */,
@@ -224,7 +205,6 @@
 				297196532B71538C000F7960 /* FilePickerService.swift in Sources */,
 				297196492B7150B5000F7960 /* ConsoleView.swift in Sources */,
 				2996D0A92B6EEFA700B487D5 /* ConfigFileManager.swift in Sources */,
-				297196502B7151FE000F7960 /* FileManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SwiftDiffusion/ContentView.swift
+++ b/SwiftDiffusion/ContentView.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import UniformTypeIdentifiers
 
 extension Constants {
   static let horizontalPadding = CGFloat(8)
@@ -23,9 +22,10 @@ struct ContentView: View {
           .textFieldStyle(RoundedBorderTextFieldStyle())
           .font(.system(.body, design: .monospaced))
         Button("Browse...") {
-          browseFile()
+          browseForWebuiShell()
         }
-      }.padding(.horizontal, Constants.horizontalPadding)
+      }
+      .padding(.horizontal, Constants.horizontalPadding)
       
       TextEditor(text: $scriptManager.consoleOutput)
         .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity)
@@ -104,28 +104,16 @@ struct ContentView: View {
       }
     }
   }
-  
-  private func browseFile() {
-    let panel = NSOpenPanel()
-    panel.allowsMultipleSelection = false
-    panel.canChooseDirectories = false
-    
-    if let shellScriptType = UTType(filenameExtension: "sh") {
-      panel.allowedContentTypes = [shellScriptType]
-    } else {
-      print("Failed to find UTType for .sh files")
-      return
-    }
-    
-    panel.begin { (response) in
-      if response == .OK, let url = panel.urls.first, url.pathExtension == "sh" {
-        self.scriptPathInput = url.path
-        self.scriptManager.scriptPath = url.path
-      } else {
-        print("Error: Selected file is not a .sh script.")
+  /// Allows the user to browse for `webui.sh` and sets the associated path variables
+  func browseForWebuiShell() {
+    Task {
+      if let path = await FilePickerService.browseForShellFile() {
+        self.scriptPathInput = path
+        self.scriptManager.scriptPath = path
       }
     }
   }
+  
 }
 
 

--- a/SwiftDiffusion/Managers/FileManager/FileManager.swift
+++ b/SwiftDiffusion/Managers/FileManager/FileManager.swift
@@ -1,9 +1,0 @@
-//
-//  FileManager.swift
-//  SwiftDiffusion
-//
-//  Created by Justin Bush on 2/5/24.
-//
-
-import Foundation
-

--- a/SwiftDiffusion/Services/FilePickerService.swift
+++ b/SwiftDiffusion/Services/FilePickerService.swift
@@ -9,6 +9,13 @@ import Foundation
 import AppKit
 import UniformTypeIdentifiers
 
+extension Constants {
+  struct FileTypes {
+    static let shellExtension = "sh"
+    static let shellScriptType = UTType(filenameExtension: shellExtension)
+  }
+}
+
 struct FilePickerService {
   /// Presents an open panel dialog allowing the user to select a shell script file.
   ///
@@ -22,19 +29,19 @@ struct FilePickerService {
       panel.allowsMultipleSelection = false
       panel.canChooseDirectories = false
       
-      if let shellScriptType = UTType(filenameExtension: "sh") {
+      if let shellScriptType = Constants.FileTypes.shellScriptType {
         panel.allowedContentTypes = [shellScriptType]
       } else {
-        print("Failed to find UTType for .sh files")
+        print("Failed to find UTType for .\(Constants.FileTypes.shellExtension) files")
         continuation.resume(returning: nil)
         return
       }
       
       panel.begin { response in
-        if response == .OK, let url = panel.urls.first, url.pathExtension == "sh" {
+        if response == .OK, let url = panel.urls.first, url.pathExtension == Constants.FileTypes.shellExtension {
           continuation.resume(returning: url.path)
         } else {
-          print("Error: Selected file is not a .sh script.")
+          print("Error: Selected file is not a .\(Constants.FileTypes.shellExtension) script.")
           continuation.resume(returning: nil)
         }
       }

--- a/SwiftDiffusion/Services/FilePickerService.swift
+++ b/SwiftDiffusion/Services/FilePickerService.swift
@@ -1,0 +1,44 @@
+//
+//  FilePickerService.swift
+//  SwiftDiffusion
+//
+//  Created by Justin Bush on 2/5/24.
+//
+
+import Foundation
+import AppKit
+import UniformTypeIdentifiers
+
+struct FilePickerService {
+  
+  /// Presents an open panel dialog allowing the user to select a shell script file.
+  ///
+  /// This function asynchronously displays a file picker dialog configured to allow the selection of files with the `.sh` extension only. It ensures that the user cannot choose directories or multiple files. If the user selects a file and confirms, the function returns the path to the selected file. If the user cancels the dialog or selects a file of an incorrect type, the function returns `nil`.
+  ///
+  /// - Returns: A `String` representing the path to the selected `.sh` file, or `nil` if no file is selected or the operation is cancelled.
+  @MainActor
+  static func browseForShellFile() async -> String? {
+    return await withCheckedContinuation { continuation in
+      let panel = NSOpenPanel()
+      panel.allowsMultipleSelection = false
+      panel.canChooseDirectories = false
+      
+      if let shellScriptType = UTType(filenameExtension: "sh") {
+        panel.allowedContentTypes = [shellScriptType]
+      } else {
+        print("Failed to find UTType for .sh files")
+        continuation.resume(returning: nil)
+        return
+      }
+      
+      panel.begin { response in
+        if response == .OK, let url = panel.urls.first, url.pathExtension == "sh" {
+          continuation.resume(returning: url.path)
+        } else {
+          print("Error: Selected file is not a .sh script.")
+          continuation.resume(returning: nil)
+        }
+      }
+    }
+  }
+}

--- a/SwiftDiffusion/Services/FilePickerService.swift
+++ b/SwiftDiffusion/Services/FilePickerService.swift
@@ -10,7 +10,6 @@ import AppKit
 import UniformTypeIdentifiers
 
 struct FilePickerService {
-  
   /// Presents an open panel dialog allowing the user to select a shell script file.
   ///
   /// This function asynchronously displays a file picker dialog configured to allow the selection of files with the `.sh` extension only. It ensures that the user cannot choose directories or multiple files. If the user selects a file and confirms, the function returns the path to the selected file. If the user cancels the dialog or selects a file of an incorrect type, the function returns `nil`.

--- a/SwiftDiffusion/Views/ConsoleView.swift
+++ b/SwiftDiffusion/Views/ConsoleView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct ConsoleView: View {
   var body: some View {
-    Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    Text("ConsoleView here")
   }
 }
 


### PR DESCRIPTION
When calling `FilePickerService.browseFile()` from ContentView, since the function is now annotated with `@MainActor`, Swift ensures that the call is made on the main thread, which is compatible with SwiftUI's expectations for UI operations.

```swift
struct FilePickerService {

  @MainActor // ← necessary for new Swift concurrency
  static func browseForShellFile() async -> String? {
    return await withCheckedContinuation { continuation in
      let panel = NSOpenPanel()
      panel.allowsMultipleSelection = false
      panel.canChooseDirectories = false
      
      if let shellScriptType = UTType(filenameExtension: "sh") {
        panel.allowedContentTypes = [shellScriptType]
      } else {
        print("Failed to find UTType for .sh files")
        continuation.resume(returning: nil)
        return
      }
      
      panel.begin { response in
        if response == .OK, let url = panel.urls.first, url.pathExtension == "sh" {
          continuation.resume(returning: url.path)
        } else {
          print("Error: Selected file is not a .sh script.")
          continuation.resume(returning: nil)
        }
      }
    }
  }
}
```

**GPT4 PR feedback:**

> Starting with Swift concurrency, certain operations, especially those involving the user interface or other main-thread-bound actions, need to be explicitly marked to run on the main thread. This is enforced more strictly in newer versions of Swift (like Swift 6) with the introduction of stricter concurrency checks.
> 
> To resolve these errors, you need to ensure that all interactions with NSOpenPanel occur on the main actor. This can be done by marking the asynchronous function or specific code blocks to run on the main actor. Here's how to adjust your FilePickerService: