### PR TITLE
fix: delete active on non sidebar focus item

### DIFF
--- a/SwiftDiffusion/PromptView/Sidebar/SidebarView.swift
+++ b/SwiftDiffusion/PromptView/Sidebar/SidebarView.swift
@@ -423,18 +423,6 @@ struct SidebarView: View {
           }
         }
       }
-      .onAppear {
-        NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
-          if event.keyCode == KeyCodes.deleteKey.code {
-            if self.editingItemId == nil,
-               let selectedItemID = self.selectedItemID,
-               let itemToDelete = self.sidebarItems.first(where: { $0.id == selectedItemID }) {
-              self.promptForDeletion(item: itemToDelete)
-            }
-          }
-          return event
-        }
-      }
     }
     /*
     HStack {
@@ -453,6 +441,7 @@ struct SidebarView: View {
     .frame(height: 30).padding(.bottom, 10)
      */
   }
+  @State private var eventMonitor: Any?
 }
 
 #Preview {


### PR DESCRIPTION
Issue involving the sidebar delete key triggering globally.

Expected behavior: Clicking the Delete key while I side bar item is active should prompt you to delete it.

Issue: Delete key triggers globally after a sidebar item has been brought into focus.

Reproducible steps: Select a Sidebar item, start entering text into the positive prompt and try deleting that text.